### PR TITLE
add-open-multilingual-wordnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ settings.json
 
 #poetry
 poetry.toml
+
+#nltk
+nltk_data

--- a/davar/__init__.py
+++ b/davar/__init__.py
@@ -4,6 +4,8 @@ from davar.utils import Davar
 import nltk
 import __main__
 
+nltk.data.path.append(r"./nltk_data")
+
 try:
     nltk.data.find(r"corpora/omw")
 except LookupError:
@@ -14,7 +16,6 @@ try:
 except LookupError:
     nltk.download("wordnet", r"./nltk_data")
 
-nltk.data.path.append(r"./nltk_data")
 
 __version__ = "0.1.1"
 name = "davar"

--- a/davar/__init__.py
+++ b/davar/__init__.py
@@ -9,5 +9,12 @@ try:
 except LookupError:
     nltk.download("omw", r"./nltk_data")
 
+try:
+    nltk.data.find(r"corpora/wordnet")
+except LookupError:
+    nltk.download("wordnet", r"./nltk_data")
+
+nltk.data.path.append(r"./nltk_data")
+
 __version__ = "0.1.1"
 name = "davar"

--- a/davar/__init__.py
+++ b/davar/__init__.py
@@ -7,9 +7,7 @@ import __main__
 try:
     nltk.data.find(r"corpora/omw")
 except LookupError:
-    nltk.download(
-        "omw", r"./nltk_data"
-    )  # FIXME: #5 Tries to install even if already installed.`
+    nltk.download("omw", r"./nltk_data")
 
 __version__ = "0.1.1"
 name = "davar"

--- a/davar/__init__.py
+++ b/davar/__init__.py
@@ -1,7 +1,12 @@
 # import stuff to top level
 from davar.parsing import transcribe
 from davar.utils import Davar
+import nltk
 import __main__
+
+nltk.download(
+    "omw", r"./nltk_data"
+)  # FIXME: #5 Tries to install even if already installed.
 
 __version__ = "0.1.1"
 name = "davar"

--- a/davar/model.py
+++ b/davar/model.py
@@ -1,5 +1,9 @@
 from wikidata.client import Client
 from re import compile
+import nltk
+
+nltk.download("omw")
+from nltk.corpus import wordnet as wn
 
 
 class DavarWord:
@@ -105,6 +109,34 @@ class WikidataProperty(Rel):
         Finds the label of a WikiData item given a two letter language code.
         """
         return self.data.label[lang]  # returns same regardless of level
+
+
+class OMWSynset(Node, Rel):
+    """
+    A synset from the open multilingual wordnet.
+    """
+
+    _compiled_id_regex = compile(r"\d{8}-[v|r|n|a]")
+
+    def __init__(self, id: str):
+        super().__init__(id)
+
+    @classmethod
+    def _validate_id(cls, id):
+        if cls._compiled_id_regex.fullmatch(id) == None:
+            raise ValueError(
+                f"{id} is not a valid Open Multilingual WordNet synset offset"
+            )
+
+    def describe(
+        self, lang: str, lvl: int = 0
+    ) -> str:  # FIXME: It is impossible to use this together with Wikidata items because they use a different language scheme.
+        """
+        Gives the lemma (name) of a Open Multilingual Wordnet synset in a language given in a 3 letter code 
+        """
+        return wn.synset_from_pos_and_offset(
+            self.id[-1], int(self.id[:-2])
+        ).lemma_names(lang)[0]
 
 
 class Statement:

--- a/davar/model.py
+++ b/davar/model.py
@@ -1,9 +1,7 @@
 from wikidata.client import Client
 from re import compile
-import nltk
-
-nltk.download("omw")
 from nltk.corpus import wordnet as wn
+import pycountry
 
 
 class DavarWord:
@@ -136,7 +134,7 @@ class OMWSynset(Node, Rel):
         """
         return wn.synset_from_pos_and_offset(
             self.id[-1], int(self.id[:-2])
-        ).lemma_names(lang)[0]
+        ).lemma_names(_bcp_42_to_iso_639_2(lang))[0]
 
 
 class Statement:
@@ -225,3 +223,7 @@ class LabeledEdge(Edge):
             return f"{sub_label} → {ob_label} ({rel_label})."
         else:  # give utilitarian formatting if it is not
             return f"[{sub_label} → {ob_label} ({rel_label})]"
+
+
+def _bcp_42_to_iso_639_2(lang_code):
+    return pycountry.languages.get(alpha_2=lang_code).alpha_3

--- a/davar/parsing.py
+++ b/davar/parsing.py
@@ -58,8 +58,8 @@ class DavarVisitor(PTNodeVisitor):
         Instantiates a OMWSynset for each synset
         """
         if self.debug:
-            print(f"Instantiating OMWSynset from {children}.")
-        return model.OMWSynset(children[0])
+            print(f"Instantiating OMWSynset from {node.value}.")
+        return model.OMWSynset(node.value)
 
     def visit_edge(self, node, children):
         """

--- a/davar/parsing.py
+++ b/davar/parsing.py
@@ -10,11 +10,15 @@ def q_id(): return "Q", numerical_id
 
 def p_id(): return "P", numerical_id
 
-def node(): return [q_id, statement]
+def synset(): return _(r'\d{8}\-[v|r|n|a]')
+
+def node(): return [q_id, statement, synset]
+
+def rel(): return [p_id, synset]
 
 def edge(): return "(", node, node, ")"
 
-def labelededge(): return "(", p_id, node, node, ")"
+def labelededge(): return "(", rel, node, node, ")"
 
 def singletonstatement(): return "(", node, ")"
 
@@ -48,6 +52,14 @@ class DavarVisitor(PTNodeVisitor):
         if self.debug:
             print(f"Instantiating WikidataProperty from {children}.")
         return model.WikidataProperty(f"P{children[0]}")
+
+    def visit_synset(self, node, children):
+        """
+        Instantiates a OMWSynset for each synset
+        """
+        if self.debug:
+            print(f"Instantiating OMWSynset from {children}.")
+        return model.OMWSynset(children[0])
 
     def visit_edge(self, node, children):
         """

--- a/davar/utils.py
+++ b/davar/utils.py
@@ -1,5 +1,4 @@
 from davar.parsing import transcribe
-from davar.model import Statement
 
 
 class Davar:

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,7 +86,7 @@ typed-ast = ">=1.4.0"
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Composable command line interface toolkit"
 name = "click"
 optional = false
@@ -133,6 +133,14 @@ requirements = ["pipreqs", "pip-api"]
 xdg_home = ["appdirs (>=1.4.0)"]
 
 [[package]]
+category = "main"
+description = "Lightweight pipelining: using Python functions as pipeline jobs."
+name = "joblib"
+optional = false
+python-versions = ">=3.6"
+version = "0.15.1"
+
+[[package]]
 category = "dev"
 description = "A fast and thorough lazy object proxy."
 name = "lazy-object-proxy"
@@ -155,6 +163,28 @@ name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
 version = "8.3.0"
+
+[[package]]
+category = "main"
+description = "Natural Language Toolkit"
+name = "nltk"
+optional = false
+python-versions = "*"
+version = "3.5"
+
+[package.dependencies]
+click = "*"
+joblib = "*"
+regex = "*"
+tqdm = "*"
+
+[package.extras]
+all = ["requests", "numpy", "python-crfsuite", "scikit-learn", "twython", "pyparsing", "scipy", "matplotlib", "gensim"]
+corenlp = ["requests"]
+machine_learning = ["gensim", "numpy", "python-crfsuite", "scikit-learn", "scipy"]
+plot = ["matplotlib"]
+tgrep = ["pyparsing"]
+twitter = ["twython"]
 
 [[package]]
 category = "dev"
@@ -258,7 +288,7 @@ python-versions = "*"
 version = "2020.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
@@ -280,6 +310,17 @@ name = "toml"
 optional = false
 python-versions = "*"
 version = "0.10.1"
+
+[[package]]
+category = "main"
+description = "Fast, Extensible Progress Meter"
+name = "tqdm"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "4.46.0"
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
 
 [[package]]
 category = "dev"
@@ -330,7 +371,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "092ab23146feb87c89eb294591407dc2e254a206abe5ab29e2dcccb78446221a"
+content-hash = "1bd3f107c82a639c5c5061ea97e49706f36487fd4b2ab916ca88fb4b7e6c0b65"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -378,6 +419,10 @@ isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
     {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
+joblib = [
+    {file = "joblib-0.15.1-py3-none-any.whl", hash = "sha256:6825784ffda353cc8a1be573118085789e5b5d29401856b35b756645ab5aecb5"},
+    {file = "joblib-0.15.1.tar.gz", hash = "sha256:61e49189c84b3c5d99a969d314853f4d1d263316cc694bec17548ebaa9c47b6e"},
+]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
     {file = "lazy_object_proxy-1.4.3-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442"},
@@ -408,6 +453,9 @@ mccabe = [
 more-itertools = [
     {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
     {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
+]
+nltk = [
+    {file = "nltk-3.5.zip", hash = "sha256:845365449cd8c5f9731f7cb9f8bd6fd0767553b9d53af9eb1b3abf7700936b35"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -471,6 +519,10 @@ six = [
 toml = [
     {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+]
+tqdm = [
+    {file = "tqdm-4.46.0-py2.py3-none-any.whl", hash = "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"},
+    {file = "tqdm-4.46.0.tar.gz", hash = "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -231,6 +231,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.1"
 
 [[package]]
+category = "main"
+description = "ISO country, subdivision, language, currency and script definitions and their translations"
+name = "pycountry"
+optional = false
+python-versions = "*"
+version = "19.8.18"
+
+[[package]]
 category = "dev"
 description = "python code static checker"
 name = "pylint"
@@ -371,7 +379,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "1bd3f107c82a639c5c5061ea97e49706f36487fd4b2ab916ca88fb4b7e6c0b65"
+content-hash = "1cf278f75b2a4cc03df83da1dc05635570211dfe71a59e8e6ff9551f415617fa"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -472,6 +480,9 @@ pluggy = [
 py = [
     {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
     {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+]
+pycountry = [
+    {file = "pycountry-19.8.18.tar.gz", hash = "sha256:3c57aa40adcf293d59bebaffbe60d8c39976fba78d846a018dc0c2ec9c6cb3cb"},
 ]
 pylint = [
     {file = "pylint-2.5.2-py3-none-any.whl", hash = "sha256:dd506acce0427e9e08fb87274bcaa953d38b50a58207170dbf5b36cf3e16957b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ python = "^3.7"
 arpeggio = "^1.9.2"
 wikidata = "^0.6.1"
 nltk = "^3.5"
+pycountry = "^19.8.18"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ include = [
 python = "^3.7"
 arpeggio = "^1.9.2"
 wikidata = "^0.6.1"
+nltk = "^3.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.2"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -74,6 +74,21 @@ class TestWikidataProperty:
         assert str(cached_WikidataProperty_P31) == "P31"
 
 
+class TestOWNSynset:
+    def test_describe(self):
+        assert m.OMWSynset("02084071-n").describe("eng") == "dog"
+
+    def test_repr(self):
+        assert repr(m.OMWSynset("02084071-n")) == 'OMWSynset("02084071-n")'
+
+    def test_str(self):
+        assert str(m.OMWSynset("02084071-n")) == "02084071-n"
+
+    def test_validate(self):
+        with pytest.raises(ValueError):
+            m.OMWSynset("Q42")
+
+
 class TestStatement:
     def test_repr(self, cached_WikidataItem_Q42):
         s = m.Statement(cached_WikidataItem_Q42)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -76,7 +76,7 @@ class TestWikidataProperty:
 
 class TestOWNSynset:
     def test_describe(self):
-        assert m.OMWSynset("02084071-n").describe("eng") == "dog"
+        assert m.OMWSynset("02084071-n").describe("en") == "dog"
 
     def test_repr(self):
         assert repr(m.OMWSynset("02084071-n")) == 'OMWSynset("02084071-n")'
@@ -249,3 +249,7 @@ class TestLabeledEdgeNested:
             ).describe("en")
             == "Douglas Adams → [Douglas Adams → human (instance of)] (instance of)."
         )
+
+
+def test__bcp_42_to_iso_639_2():
+    assert m._bcp_42_to_iso_639_2("en") == "eng"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -60,12 +60,19 @@ def test_transcribe_nested_Statements():
     ]
 
 
-@pytest.mark.xfail
 def test_transcribe_OWNSynsets():
     assert parsing.transcribe("(01835496-v 02084071-n 00110659-r)", debug=True) == [
         m.LabeledEdge(
             m.OMWSynset("01835496-v"),
             m.OMWSynset("02084071-n"),
             m.OMWSynset("00110659-r"),
+        )
+    ]
+
+
+def test_transcribe_mixed():
+    assert parsing.transcribe("(01704452-v Q42 03833065-n)", debug=True) == [
+        m.LabeledEdge(
+            m.OMWSynset("01704452-v"), m.WikidataItem("Q42"), m.OMWSynset("03833065-n"),
         )
     ]

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,68 +1,71 @@
 from davar import parsing
-from davar import model
+from davar import model as m
 import pytest
 
 
 def test_transcribe_singletonStatement():
-    assert parsing.transcribe("(Q5)") == [model.Statement(model.WikidataItem("Q5"))]
+    assert parsing.transcribe("(Q5)") == [m.Statement(m.WikidataItem("Q5"))]
 
 
 def test_transcribe_Edge():
     assert parsing.transcribe("(Q42 Q5)") == [
-        model.Edge(model.WikidataItem("Q42"), model.WikidataItem("Q5"))
+        m.Edge(m.WikidataItem("Q42"), m.WikidataItem("Q5"))
     ]
 
 
 def test_transcribe_LabeledEdge():
     assert parsing.transcribe("(P31 Q42 Q5)") == [
-        model.LabeledEdge(
-            model.WikidataProperty("P31"),
-            model.WikidataItem("Q42"),
-            model.WikidataItem("Q5"),
+        m.LabeledEdge(
+            m.WikidataProperty("P31"), m.WikidataItem("Q42"), m.WikidataItem("Q5"),
         )
     ]
 
 
 def test_transcribe_multiple_LabeledEdges():
     assert parsing.transcribe("(P31 Q42 Q5) (P106 Q3236990 Q5482740)") == [
-        model.LabeledEdge(
-            model.WikidataProperty("P31"),
-            model.WikidataItem("Q42"),
-            model.WikidataItem("Q5"),
+        m.LabeledEdge(
+            m.WikidataProperty("P31"), m.WikidataItem("Q42"), m.WikidataItem("Q5"),
         ),
-        model.LabeledEdge(
-            model.WikidataProperty("P106"),
-            model.WikidataItem("Q3236990"),
-            model.WikidataItem("Q5482740"),
+        m.LabeledEdge(
+            m.WikidataProperty("P106"),
+            m.WikidataItem("Q3236990"),
+            m.WikidataItem("Q5482740"),
         ),
     ]
 
 
 def test_transcribe_multiple_Statements():
     assert parsing.transcribe("(Q5)(P31 Q42 Q5) (Q5 Q42) (P106 Q3236990 Q5482740)") == [
-        model.Statement(model.WikidataItem("Q5")),
-        model.LabeledEdge(
-            model.WikidataProperty("P31"),
-            model.WikidataItem("Q42"),
-            model.WikidataItem("Q5"),
+        m.Statement(m.WikidataItem("Q5")),
+        m.LabeledEdge(
+            m.WikidataProperty("P31"), m.WikidataItem("Q42"), m.WikidataItem("Q5"),
         ),
-        model.Edge(model.WikidataItem("Q5"), model.WikidataItem("Q42")),
-        model.LabeledEdge(
-            model.WikidataProperty("P106"),
-            model.WikidataItem("Q3236990"),
-            model.WikidataItem("Q5482740"),
+        m.Edge(m.WikidataItem("Q5"), m.WikidataItem("Q42")),
+        m.LabeledEdge(
+            m.WikidataProperty("P106"),
+            m.WikidataItem("Q3236990"),
+            m.WikidataItem("Q5482740"),
         ),
     ]
 
 
 def test_transcribe_nested_Statements():
     assert parsing.transcribe("(Q5482740 (P31 Q42 Q5))", debug=True) == [
-        model.Edge(
-            model.WikidataItem("Q5482740"),
-            model.LabeledEdge(
-                model.WikidataProperty("P31"),
-                model.WikidataItem("Q42"),
-                model.WikidataItem("Q5"),
+        m.Edge(
+            m.WikidataItem("Q5482740"),
+            m.LabeledEdge(
+                m.WikidataProperty("P31"), m.WikidataItem("Q42"), m.WikidataItem("Q5"),
             ),
+        )
+    ]
+
+
+@pytest.mark.xfail
+def test_transcribe_OWNSynsets():
+    assert parsing.transcribe("(01835496-v 02084071-n 00110659-r)", debug=True) == [
+        m.LabeledEdge(
+            m.OMWSynset("01835496-v"),
+            m.OMWSynset("02084071-n"),
+            m.OMWSynset("00110659-r"),
         )
     ]


### PR DESCRIPTION
adds Open Multilingual WordNet Synset as a new Node and Rel type for davar.
- `OMWSynset` node and rel added
- davar now downloads "omw" and "wordnet" from nltk to ./ntlk_data on init
-./ntlk_data added to .gitignore
- new tests for the new features